### PR TITLE
# Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,25 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 2.6
-          - 2.7
-          - 3.0
+          - '2.7'
+          - '3.0'
+          - '3.1'
+        gemfile:
+          - gemfiles/Gemfile.rails60
+          - gemfiles/Gemfile.rails61
+          - gemfiles/Gemfile.rails70
+        exclude:
+          # rails 7.0 requires ruby >= 2.7
+          # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
+          - ruby-version: '2.6'
+            gemfile: 'gemfiles/Gemfile.rails70'
 
-    name: Ruby ${{ matrix.ruby-version }}
+    name: Ruby ${{ matrix.ruby-version }} / Bundle ${{ matrix.gemfile }}
 
     runs-on: ubuntu-latest
+
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
-*no unreleased changes*
+* Drop support for Ruby 2.6
+* Support Ruby 3.1, Rails 7.0
+* Replace Public Health England naming with NHS Digital
 
 ## 5.8.0 / 2022-07-18
 * Added new 'badger_search' registration action type filter (#86)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Public Health England
+Copyright (c) 2015-2022 NHS Digital
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# CANQL [![Build Status](https://github.com/publichealthengland/canql/workflows/Test/badge.svg)](https://github.com/publichealthengland/canql/actions?query=workflow%3Atest) [![Gem Version](https://badge.fury.io/rb/canql.svg)](https://rubygems.org/gems/canql)
+# CANQL [![Build Status](https://github.com/NHSDigital/canql/workflows/Test/badge.svg)](https://github.com/NHSDigital/canql/actions?query=workflow%3Atest) [![Gem Version](https://badge.fury.io/rb/canql.svg)](https://rubygems.org/gems/canql)
 
-Congenital Anomaly Natural Query Language (CANQL) is a [Treetop](http://treetop.rubyforge.org/)-driven Domain Specific Language (DSL) used by the Public Health England (PHE) National Congenital Anomaly and Rare Disease Registration Service (NCARDRS) to identify cohorts of cases.
+Congenital Anomaly Natural Query Language (CANQL) is a [Treetop](http://treetop.rubyforge.org/)-driven Domain Specific Language (DSL) used by the NHS Digital (NHS-D) National Congenital Anomaly and Rare Disease Registration Service (NCARDRS) to identify cohorts of cases.
 
 Used for analysis, research and day-to-day operations to empower non-technical users to write sophisticated human readable queries without the need to know or understand the underlying datastore and/or schema.
 
 CANQL is decoupled from the specifics of the NCARDRS systems by producing an intermediate representation, known as Disease Intermediate Representation (DIR). This allows us to:
 
 1. implement separate DIR adapters for different datastores (e.g. SQL and NoSQL datastores);
-2. utilize the same DIR adapters for different but over-lapping DSLs, including Tumour Natural Query Language ([TNQL](https://github.com/PublicHealthEngland/tnql)) ; and
+2. utilize the same DIR adapters for different but over-lapping DSLs, including Tumour Natural Query Language ([TNQL](https://github.com/NHSDigital/tnql)) ; and
 3. pass DIR queries to non-ruby backend systems using any simple format like JSON.
 
 ## Installation
@@ -62,7 +62,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-1. Fork it ( https://github.com/PublicHealthEngland/canql/fork )
+1. Fork it ( https://github.com/NHSDigital/canql/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/canql.gemspec
+++ b/canql.gemspec
@@ -1,42 +1,41 @@
 # frozen_string_literal: true
-# coding: utf-8
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'canql/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'canql'
   spec.version       = Canql::VERSION
-  spec.authors       = ['PHE NDR Development Team']
+  spec.authors       = ['NHSD NDRS Development Team']
   spec.email         = []
 
   spec.summary       = 'Congenital Anomaly Natural Query Language'
   spec.description   = 'Domain Specific Language for querying PHE NCARDRS datastores'
-  spec.homepage      = 'https://github.com/PublicHealthEngland/canql'
+  spec.homepage      = 'https://github.com/NHSDigital/canql'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 2.4'
-
+  gem_files          = %w[CHANGELOG.md CODE_OF_CONDUCT.md LICENSE.txt README.md Rakefile
+                          app config db lib]
   spec.files         = `git ls-files -z`.split("\x0").
-                       reject { |f| f.match(%r{^(test|spec|features)/}) }
-  # SECURE BNS 2018-08-06: Minimise sharing of (public-key encrypted) slack secrets in .travis.yml
-  spec.files         -= %w[.travis.yml] # Not needed in the gem
+                       select { |f| gem_files.include?(f.split('/')[0]) }
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.7'
+
   spec.add_dependency 'chronic', '~> 0.3'
   spec.add_dependency 'ndr_support', '>= 3.0', '< 6'
-  spec.add_dependency 'rails', '>= 4.1', '< 7'
+  spec.add_dependency 'rails', '>= 6.0', '< 7.1'
   spec.add_dependency 'treetop', '>= 1.4.10'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'guard'
   spec.add_development_dependency 'guard-minitest'
   spec.add_development_dependency 'guard-rubocop'
-  spec.add_development_dependency 'minitest'
-  spec.add_development_dependency 'ndr_dev_support', '~> 5.9'
+  spec.add_development_dependency 'minitest', '>= 5.0.0'
+  spec.add_development_dependency 'ndr_dev_support', '>= 6.0', '< 8.0'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'terminal-notifier-guard' if RUBY_PLATFORM =~ /darwin/

--- a/gemfiles/Gemfile.rails60
+++ b/gemfiles/Gemfile.rails60
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 6.0'

--- a/gemfiles/Gemfile.rails61
+++ b/gemfiles/Gemfile.rails61
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 6.1.0'
+

--- a/gemfiles/Gemfile.rails70
+++ b/gemfiles/Gemfile.rails70
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails',  '~> 7.0.0'


### PR DESCRIPTION
# Support Ruby 3.1, Rails 7.0
# Replace Public Health England naming with NHS Digital