### PR TITLE
Added new `other` filter to anomaly grammar (Resolves #90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-* No unreleased changes
+* Add 'other' option to anomaly screening status filter (#90)
 
 ## 5.8.1 / 2022-12-08
 * Drop support for Ruby 2.6

--- a/canql.gemspec
+++ b/canql.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email         = []
 
   spec.summary       = 'Congenital Anomaly Natural Query Language'
-  spec.description   = 'Domain Specific Language for querying PHE NCARDRS datastores'
+  spec.description   = 'Domain Specific Language for querying NHS NCARDRS datastores'
   spec.homepage      = 'https://github.com/NHSDigital/canql'
   spec.license       = 'MIT'
 

--- a/lib/canql/grammars/anomaly.treetop
+++ b/lib/canql/grammars/anomaly.treetop
@@ -23,7 +23,7 @@ module Canql
        'ics' / 'ineligible unbooked' / 'inb' / 'early detected' / 'ied' /
        'screen declined' / 'sd' / 'ineligible early loss' / 'iefl' / 'ineligible top' /
        'itop' / 'missed screen' / 'ms' / 'excluded' / 'exc' / 'detected' /
-       'undetected' / 'ineligible' / 'pending data') word_break
+       'undetected' / 'ineligible' / 'pending data' / 'other') word_break
     end
 
     rule anomalies_keyword

--- a/test/nodes/anomaly_test.rb
+++ b/test/nodes/anomaly_test.rb
@@ -115,7 +115,7 @@ class AnomalyTest < Minitest::Test
       'qtneg', 'nonwindow', 'nws', 'incomplete screen', 'ics', 'ineligible unbooked', 'inb',
       'early detected', 'ied', 'screen declined', 'sd', 'ineligible early loss', 'iefl',
       'ineligible top', 'itop', 'missed screen', 'ms', 'excluded', 'exc', 'detected',
-      'undetected', 'ineligible', 'pending data'
+      'undetected', 'ineligible', 'pending data', 'other'
     ]
     possible_statuses.each do |screening_status|
       query = "all cases with some #{screening_status} anomalies"


### PR DESCRIPTION
- Added 'other' to the availalbe anomaly screening other_screening_status
- Added `other` to the anomaly screening status test