### PR TITLE
Cleaned up code (NDRS2-2004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## [Unreleased]
+## Fixed
+* Code only misspelling of existence
+* Code only misspelling of modifier
+* Code only misspelling of number
+* Code only misspelling of acceptance
 
 ## 6.0.0 / 2024-09-30
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,13 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in canql.gemspec
 gemspec
+
+gem 'bundler'
+gem 'guard'
+gem 'guard-minitest'
+gem 'guard-rubocop'
+gem 'minitest', '>= 5.0.0'
+gem 'ndr_dev_support', '>= 6.0', '< 8.0'
+gem 'pry'
+gem 'rake'
+gem 'terminal-notifier-guard' if RUBY_PLATFORM =~ /darwin/

--- a/canql.gemspec
+++ b/canql.gemspec
@@ -30,13 +30,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '>= 6.0', '< 7.1'
   spec.add_dependency 'treetop', '>= 1.4.10'
 
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'guard'
-  spec.add_development_dependency 'guard-minitest'
-  spec.add_development_dependency 'guard-rubocop'
-  spec.add_development_dependency 'minitest', '>= 5.0.0'
-  spec.add_development_dependency 'ndr_dev_support', '>= 6.0', '< 8.0'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'terminal-notifier-guard' if RUBY_PLATFORM =~ /darwin/
+  # spec.add_development_dependency 'bundler'
+  # spec.add_development_dependency 'guard'
+  # spec.add_development_dependency 'guard-minitest'
+  # spec.add_development_dependency 'guard-rubocop'
+  # spec.add_development_dependency 'minitest', '>= 5.0.0'
+  # spec.add_development_dependency 'ndr_dev_support', '>= 6.0', '< 8.0'
+  # spec.add_development_dependency 'pry'
+  # spec.add_development_dependency 'rake'
+  # spec.add_development_dependency 'terminal-notifier-guard' if RUBY_PLATFORM =~ /darwin/
 end

--- a/gemfiles/Gemfile.rails60
+++ b/gemfiles/Gemfile.rails60
@@ -3,3 +3,14 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'rails', '~> 6.0'
+
+gem 'bundler'
+gem 'guard'
+gem 'guard-minitest'
+gem 'guard-rubocop'
+gem 'minitest', '>= 5.0.0'
+gem 'ndr_dev_support', '>= 6.0', '< 8.0'
+gem 'github-linguist'
+gem 'pry'
+gem 'rake'
+gem 'terminal-notifier-guard' if RUBY_PLATFORM =~ /darwin/

--- a/gemfiles/Gemfile.rails61
+++ b/gemfiles/Gemfile.rails61
@@ -4,3 +4,13 @@ gemspec path: '..'
 
 gem 'rails', '~> 6.1.0'
 
+gem 'bundler'
+gem 'guard'
+gem 'guard-minitest'
+gem 'guard-rubocop'
+gem 'minitest', '>= 5.0.0'
+gem 'ndr_dev_support', '>= 6.0', '< 8.0'
+gem 'github-linguist'
+gem 'pry'
+gem 'rake'
+gem 'terminal-notifier-guard' if RUBY_PLATFORM =~ /darwin/

--- a/gemfiles/Gemfile.rails70
+++ b/gemfiles/Gemfile.rails70
@@ -3,3 +3,14 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'rails',  '~> 7.0.0'
+
+gem 'bundler'
+gem 'guard'
+gem 'guard-minitest'
+gem 'guard-rubocop'
+gem 'minitest', '>= 5.0.0'
+gem 'ndr_dev_support', '>= 6.0', '< 8.0'
+gem 'github-linguist'
+gem 'pry'
+gem 'rake'
+gem 'terminal-notifier-guard' if RUBY_PLATFORM =~ /darwin/

--- a/lib/canql/grammars/anomaly.treetop
+++ b/lib/canql/grammars/anomaly.treetop
@@ -1,7 +1,7 @@
 module Canql
   grammar Anomaly
     rule anomalies
-      and_keyword? existance_modifier:anomalies_no_keyword? status_type:anomaly_status? natal_period:anomalies_natal_period? screening_status_type:anomaly_screening_status? code_data:(space first:anomalies_icd_code rest:more_anomalies_icd_codes* word_break)? anomalies_keyword <Nodes::Anomaly::WithCondition>
+      and_keyword? existence_modifier:anomalies_no_keyword? status_type:anomaly_status? natal_period:anomalies_natal_period? screening_status_type:anomaly_screening_status? code_data:(space first:anomalies_icd_code rest:more_anomalies_icd_codes* word_break)? anomalies_keyword <Nodes::Anomaly::WithCondition>
     end
 
     rule anomalies_no_keyword

--- a/lib/canql/grammars/events.treetop
+++ b/lib/canql/grammars/events.treetop
@@ -1,7 +1,7 @@
 module Canql
   grammar Events
     rule events
-      and_keyword? existance_modifier:events_no_keyword? events_name event_object_keyword <Nodes::Events::WithCondition>
+      and_keyword? existence_modifier:events_no_keyword? events_name event_object_keyword <Nodes::Events::WithCondition>
     end
 
     rule events_no_keyword

--- a/lib/canql/grammars/genetic_test.treetop
+++ b/lib/canql/grammars/genetic_test.treetop
@@ -1,7 +1,7 @@
 module Canql
   grammar GeneticTest
     rule genetic_tests
-      and_keyword? existance_modifier:genetic_tests_no_keyword? genetic_tests_keyword <Nodes::GeneticTest::WithCondition>
+      and_keyword? existence_modifier:genetic_tests_no_keyword? genetic_tests_keyword <Nodes::GeneticTest::WithCondition>
     end
 
     rule genetic_tests_no_keyword

--- a/lib/canql/grammars/main.treetop
+++ b/lib/canql/grammars/main.treetop
@@ -92,7 +92,7 @@ grammar Canql
      space 'and' word_break
   end
 
-  rule existance_keyword
+  rule existence_keyword
      space ('missing' / ('field' 's'?) / 'populated') word_break
   end
 
@@ -130,12 +130,12 @@ grammar Canql
 
   rule case_with_conditions
      anomalies / genetic_tests / test_results / perinatal_hospital /
-     case_field_existance / test_acceptance_existance / test_result_groups /
+     case_field_existence / test_acceptance_existence / test_result_groups /
      mother_conditions / action_or_ebr / events
   end
 
   rule patient_with_conditions
-     anomalies / genetic_tests / test_results / patient_field_existance /
+     anomalies / genetic_tests / test_results / patient_field_existence /
      action_or_ebr / events
   end
 end

--- a/lib/canql/grammars/patient.treetop
+++ b/lib/canql/grammars/patient.treetop
@@ -30,12 +30,12 @@ module Canql
       expected_keyword fuzzy_date <Nodes::Patient::ExpectedDateRangeNode>
     end
 
-    rule case_field_existance
-      and_keyword? field_existance_modifier:existance_keyword patient_field_list:case_field_list  <Nodes::Patient::FieldExists>
+    rule case_field_existence
+      and_keyword? field_existence_modifier:existence_keyword patient_field_list:case_field_list  <Nodes::Patient::FieldExists>
     end
 
-    rule patient_field_existance
-      and_keyword? field_existance_modifier:existance_keyword patient_field_list:patient_field_list  <Nodes::Patient::FieldExists>
+    rule patient_field_existence
+      and_keyword? field_existence_modifier:existence_keyword patient_field_list:patient_field_list  <Nodes::Patient::FieldExists>
     end
 
     rule patient_fields_keyword
@@ -84,7 +84,7 @@ module Canql
     end
 
     rule mother_with_conditions
-      patient_field_existance / action_or_ebr
+      patient_field_existence / action_or_ebr
     end
   end
 end

--- a/lib/canql/grammars/test_result.treetop
+++ b/lib/canql/grammars/test_result.treetop
@@ -1,7 +1,7 @@
 module Canql
   grammar TestResult
     rule test_results
-      and_keyword? existance_modifier:test_result_no_keyword? natal_period:test_result_natal_period? test_results_keyword <Nodes::TestResult::WithCondition>
+      and_keyword? existence_modifier:test_result_no_keyword? natal_period:test_result_natal_period? test_results_keyword <Nodes::TestResult::WithCondition>
     end
 
     rule test_result_no_keyword

--- a/lib/canql/grammars/test_result_group.treetop
+++ b/lib/canql/grammars/test_result_group.treetop
@@ -1,10 +1,10 @@
 module Canql
   grammar TestResultGroup
     rule test_result_groups
-      and_keyword? existance_modifier:test_result_group_existance_keyword group:test_result_group_names <Nodes::TestResultGroup::WithCondition>
+      and_keyword? existence_modifier:test_result_group_existence_keyword group:test_result_group_names <Nodes::TestResultGroup::WithCondition>
     end
 
-    rule test_result_group_existance_keyword
+    rule test_result_group_existence_keyword
       # If in furture the reverse is needed use 'supplied require'
       space ('missing required' / 'missing' / 'supplied required' / 'supplied') word_break
     end
@@ -13,11 +13,11 @@ module Canql
       space ('screening' / 'anomaly scan' / 'fetal medicine' / 'dating') word_break
     end
 
-    rule test_acceptance_existance
-      and_keyword? existance_modifier:test_acceptance_existance_keyword acceptance:test_acceptance_names <Nodes::TestAcceptanceExistamce::WithCondition>
+    rule test_acceptance_existence
+      and_keyword? existence_modifier:test_acceptance_existence_keyword acceptance:test_acceptance_names <Nodes::TestAcceptanceExistence::WithCondition>
     end
 
-    rule test_acceptance_existance_keyword
+    rule test_acceptance_existence_keyword
       space ('missing required' / 'missing' ) word_break
     end
 

--- a/lib/canql/nodes/age.rb
+++ b/lib/canql/nodes/age.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Canql #:nodoc: all
+module Canql # :nodoc: all
   module Nodes
     module Age
       module BirthDateNode

--- a/lib/canql/nodes/anomaly.rb
+++ b/lib/canql/nodes/anomaly.rb
@@ -30,9 +30,7 @@ module Canql # :nodoc: all
 
         def code_filters(anomaly_hash)
           anomaly_hash['icd_codes'] = code_filter[:icd_code] if code_filter[:icd_code].present?
-          if code_filter[:code_group].present?
-            anomaly_hash['code_groups'] = code_filter[:code_group]
-          end
+          anomaly_hash['code_groups'] = code_filter[:code_group] if code_filter[:code_group].present?
           return if code_filter[:fasp_rating].blank?
 
           anomaly_hash['fasp_rating'] = code_filter[:fasp_rating]
@@ -73,28 +71,20 @@ module Canql # :nodoc: all
           clean_code_array(code_array)
 
           code_filters = {}
-          if code_array[:icd_code].any?
-            code_filters[:icd_code] = { Canql::BEGINS => code_array[:icd_code] }
-          end
-
-          if code_array[:code_group].any?
-            code_filters[:code_group] = { Canql::EQUALS => code_array[:code_group] }
-          end
-
-          if code_array[:fasp_rating].any?
-            code_filters[:fasp_rating] = { Canql::EQUALS => code_array[:fasp_rating] }
-          end
+          code_filters[:icd_code] = { Canql::BEGINS => code_array[:icd_code] } if code_array[:icd_code].any?
+          code_filters[:code_group] = { Canql::EQUALS => code_array[:code_group] } if code_array[:code_group].any?
+          code_filters[:fasp_rating] = { Canql::EQUALS => code_array[:fasp_rating] } if code_array[:fasp_rating].any?
 
           code_filters
         end
 
         def clean_code_array(code_array)
           code_array[:icd_code].flatten!
-          code_array[:icd_code].delete_if(&:blank?)
+          code_array[:icd_code].compact_blank!
           code_array[:code_group].flatten!
-          code_array[:code_group].delete_if(&:blank?)
+          code_array[:code_group].compact_blank!
           code_array[:fasp_rating].flatten!
-          code_array[:fasp_rating].delete_if(&:blank?)
+          code_array[:fasp_rating].compact_blank!
         end
 
         def code_filter

--- a/lib/canql/nodes/anomaly.rb
+++ b/lib/canql/nodes/anomaly.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Canql #:nodoc: all
+module Canql # :nodoc: all
   module Nodes
     module Anomaly
       module WithCondition
@@ -17,7 +17,7 @@ module Canql #:nodoc: all
         end
 
         def to_anomaly
-          anomaly_hash = { 'exists' => existance_filter }
+          anomaly_hash = { 'exists' => existence_filter }
           anomaly_hash['type'] = anomaly_type_filter if anomaly_type.present?
           anomaly_hash['status'] = anomaly_status_type_filter if anomaly_status_type.present?
           if anomaly_screening_status_type.present?
@@ -38,8 +38,8 @@ module Canql #:nodoc: all
           anomaly_hash['fasp_rating'] = code_filter[:fasp_rating]
         end
 
-        def existance_filter
-          { Canql::EQUALS => existance_modifier.text_value.strip != 'no' }
+        def existence_filter
+          { Canql::EQUALS => existence_modifier.text_value.strip != 'no' }
         end
 
         def anomaly_type_filter

--- a/lib/canql/nodes/dates.rb
+++ b/lib/canql/nodes/dates.rb
@@ -3,7 +3,7 @@
 require 'chronic'
 require 'ndr_support/daterange'
 
-module Canql #:nodoc: all
+module Canql # :nodoc: all
   module Nodes
     module FuzzyDateNode
       delegate :to_daterange, to: :date
@@ -25,12 +25,12 @@ module Canql #:nodoc: all
     module YearQuarterNode
       def to_daterange
         quarter = text_value[0..1]
-        year = text_value[3..-1]
+        year = text_value[3..]
         quarters = {
-          'q1': "01-04-#{year}",
-          'q2': "01-07-#{year}",
-          'q3': "01-10-#{year}",
-          'q4': "01-01-#{year.to_i + 1}"
+          q1: "01-04-#{year}",
+          q2: "01-07-#{year}",
+          q3: "01-10-#{year}",
+          q4: "01-01-#{year.to_i + 1}"
         }
         Daterange.new(quarters[quarter.to_sym].to_date,
                       quarters[quarter.to_sym].to_date + 3.months - 1.day)

--- a/lib/canql/nodes/e_base_records.rb
+++ b/lib/canql/nodes/e_base_records.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Canql #:nodoc: all
+module Canql # :nodoc: all
   module Nodes
     module EBaseRecordsNode
       def meta_data_item

--- a/lib/canql/nodes/events.rb
+++ b/lib/canql/nodes/events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Canql #:nodoc: all
+module Canql # :nodoc: all
   module Nodes
     module Events
       module WithCondition
@@ -32,7 +32,7 @@ module Canql #:nodoc: all
         end
 
         def existence_filter
-          { Canql::EQUALS => existance_modifier.text_value.strip != 'no' }
+          { Canql::EQUALS => existence_modifier.text_value.strip != 'no' }
         end
       end
     end

--- a/lib/canql/nodes/genetic_test.rb
+++ b/lib/canql/nodes/genetic_test.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 
-module Canql #:nodoc: all
+module Canql # :nodoc: all
   module Nodes
     module GeneticTest
       module WithCondition
         def to_genetic_test
-          genetic_test_hash = { 'exists' => existance_filter }
-          genetic_test_hash
+          { 'exists' => existence_filter }
         end
 
-        def existance_filter
-          { Canql::EQUALS => existance_modifier.text_value.strip != 'no' }
+        def existence_filter
+          { Canql::EQUALS => existence_modifier.text_value.strip != 'no' }
         end
       end
     end

--- a/lib/canql/nodes/main.rb
+++ b/lib/canql/nodes/main.rb
@@ -2,7 +2,7 @@
 
 # require 'active_support/core_ext/object/blank'
 
-module Canql #:nodoc: all
+module Canql # :nodoc: all
   module Nodes
     module RecordCountNode
       def meta_data_item
@@ -12,7 +12,7 @@ module Canql #:nodoc: all
   end
 end
 
-module Canql #:nodoc: all
+module Canql # :nodoc: all
   module Nodes
     # Returns a filter detailing the require result type (cases or patients)
     module SubjectNode

--- a/lib/canql/nodes/patient.rb
+++ b/lib/canql/nodes/patient.rb
@@ -66,9 +66,9 @@ module Canql # :nodoc: all
           field_names = actual_field_names(
             patient_field_list.text_values_for_marker(:patient_field_name), subject.to_sym
           )
-          modifer = field_existance_modifier.text_value.strip
-          existance = modifer == 'missing' ? 'fields_missing' : 'fields_populated'
-          { "#{subject}.#{existance}" => { Canql::EQUALS => field_names } }
+          modifier = field_existence_modifier.text_value.strip
+          existence = modifier == 'missing' ? 'fields_missing' : 'fields_populated'
+          { "#{subject}.#{existence}" => { Canql::EQUALS => field_names } }
         end
 
         def actual_field_names(fields, subject)

--- a/lib/canql/nodes/patient_events.rb
+++ b/lib/canql/nodes/patient_events.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-module Canql #:nodoc: all
+module Canql # :nodoc: all
   module Nodes
     module PatientEvents
       module WithCondition
         def to_events
-          event_name = event_type_name()
+          event_name = event_type_name
           { "#{event_name}_event" => existence_filter }
         end
 
@@ -28,7 +28,7 @@ module Canql #:nodoc: all
         end
 
         def existence_filter
-          { Canql::EQUALS => existance_modifier.text_value.strip != 'no' }
+          { Canql::EQUALS => existence_modifier.text_value.strip != 'no' }
         end
       end
     end

--- a/lib/canql/nodes/perinatal_hospital.rb
+++ b/lib/canql/nodes/perinatal_hospital.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Canql #:nodoc: all
+module Canql # :nodoc: all
   module Nodes
     module PerinatalProviderCodeNode
       def meta_data_item

--- a/lib/canql/nodes/registry.rb
+++ b/lib/canql/nodes/registry.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Canql #:nodoc: all
+module Canql # :nodoc: all
   module Nodes
     module RegistryNode
       def meta_data_item

--- a/lib/canql/nodes/test_result.rb
+++ b/lib/canql/nodes/test_result.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Canql #:nodoc: all
+module Canql # :nodoc: all
   module Nodes
     module TestResult
       module WithCondition
@@ -9,13 +9,13 @@ module Canql #:nodoc: all
         end
 
         def to_test_result
-          test_result_hash = { 'exists' => existance_filter }
+          test_result_hash = { 'exists' => existence_filter }
           test_result_hash['type'] = test_result_type_filter if test_result_type.present?
           test_result_hash
         end
 
-        def existance_filter
-          { Canql::EQUALS => existance_modifier.text_value.strip != 'no' }
+        def existence_filter
+          { Canql::EQUALS => existence_modifier.text_value.strip != 'no' }
         end
 
         def test_result_type_filter

--- a/lib/canql/nodes/test_result_group.rb
+++ b/lib/canql/nodes/test_result_group.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Canql #:nodoc: all
+module Canql # :nodoc: all
   module Nodes
     module TestResultGroup
       module WithCondition
@@ -9,16 +9,16 @@ module Canql #:nodoc: all
         end
 
         def to_test_result_group
-          test_result_group_hash = { 'exists' => existance_filter }
+          test_result_group_hash = { 'exists' => existence_filter }
           test_result_group_hash['required'] = requirement_filter
           test_result_group_hash['group'] = test_result_group_filter if test_result_group.present?
           test_result_group_hash
         end
 
-        def existance_filter
+        def existence_filter
           {
             Canql::EQUALS => ['supplied required', 'supplied'].include?(
-              existance_modifier.text_value.strip
+              existence_modifier.text_value.strip
             )
           }
         end
@@ -26,7 +26,7 @@ module Canql #:nodoc: all
         def requirement_filter
           {
             Canql::EQUALS => ['supplied required', 'missing required'].include?(
-              existance_modifier.text_value.strip
+              existence_modifier.text_value.strip
             )
           }
         end
@@ -37,23 +37,23 @@ module Canql #:nodoc: all
       end
     end
 
-    module TestAcceptanceExistamce
+    module TestAcceptanceExistence
       module WithCondition
         def test_acceptance
           acceptance.text_value.strip.parameterize.underscore
         end
 
         def to_test_acceptance
-          test_acceptance_hash = { 'exists' => existance_filter }
+          test_acceptance_hash = { 'exists' => existence_filter }
           test_acceptance_hash['required'] = requirement_filter
           test_acceptance_hash['acceptance'] = test_acceptance_filter if test_acceptance.present?
           test_acceptance_hash
         end
 
-        def existance_filter
+        def existence_filter
           {
             Canql::EQUALS => ['supplied required', 'supplied'].include?(
-              existance_modifier.text_value.strip
+              existence_modifier.text_value.strip
             )
           }
         end
@@ -61,7 +61,7 @@ module Canql #:nodoc: all
         def requirement_filter
           {
             Canql::EQUALS => ['supplied required', 'missing required'].include?(
-              existance_modifier.text_value.strip
+              existence_modifier.text_value.strip
             )
           }
         end

--- a/lib/canql/treetop/extensions.rb
+++ b/lib/canql/treetop/extensions.rb
@@ -26,7 +26,8 @@ module Treetop
 
       def reverse_scan_for_marker(marker)
         marker_value = reverse_marker_scanner(self, marker)
-        return if marker_value.nil? || marker_value.empty?
+        return if marker_value.blank?
+
         marker_value
       end
 
@@ -34,6 +35,7 @@ module Treetop
 
       def text_values_for_marker_scanner(root, marker, list)
         return if root.elements.nil?
+
         root.elements.each do |e|
           list << e.send(marker).text_value if e.respond_to?(marker)
           text_values_for_marker_scanner(e, marker, list)
@@ -43,10 +45,9 @@ module Treetop
 
       def reverse_marker_scanner(root, marker)
         return if root.nil? || root.elements.nil?
+
         marker_value = root.send(marker).text_value if root.respond_to?(marker)
-        if marker_value.nil? || marker_value.empty?
-          marker_value = reverse_marker_scanner(root.parent, marker)
-        end
+        marker_value = reverse_marker_scanner(root.parent, marker) if marker_value.blank?
         marker_value
       end
     end

--- a/test/anomaly_test_helper.rb
+++ b/test/anomaly_test_helper.rb
@@ -12,7 +12,7 @@ module AnomalyTestHelper
     )
   end
 
-  def assert_anomaly_count(parser, numder_of_blocks)
-    assert_dir_block_count(parser, 'anomalies', numder_of_blocks)
+  def assert_anomaly_count(parser, number_of_blocks)
+    assert_dir_block_count(parser, 'anomalies', number_of_blocks)
   end
 end

--- a/test/events_test_helper.rb
+++ b/test/events_test_helper.rb
@@ -8,7 +8,7 @@ module EventsTestHelper
     assert_dir_block_values(parser, "#{subject}.#{event_name}", %w[exists], index, expected)
   end
 
-  def assert_events_count(parser, subject, event_name, numder_of_blocks)
-    assert_dir_block_count(parser, "#{subject}.#{event_name}", numder_of_blocks)
+  def assert_events_count(parser, subject, event_name, number_of_blocks)
+    assert_dir_block_count(parser, "#{subject}.#{event_name}", number_of_blocks)
   end
 end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'canql'
 
 require 'minitest/autorun'

--- a/test/nodes/case_age_test.rb
+++ b/test/nodes/case_age_test.rb
@@ -7,7 +7,7 @@ class CasaAgeTest < Minitest::Test
   def test_should_filter_by_case_birth_date_range
     parser = Canql::Parser.new('all cases born between 10/01/2000 and 10/10/2010')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
+    assert_equal({ Canql::LIMITS => %w[2000-01-10 2010-10-10] },
                  parser.meta_data['patient.birthdate'])
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -15,7 +15,7 @@ class CasaAgeTest < Minitest::Test
   def test_should_filter_by_case_exect_birth_date
     parser = Canql::Parser.new('all cases born on 10/01/2000')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
+    assert_equal({ Canql::LIMITS => %w[2000-01-10 2000-01-10] },
                  parser.meta_data['patient.birthdate'])
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -23,7 +23,7 @@ class CasaAgeTest < Minitest::Test
   def test_should_filter_by_mothers_birth_date_range
     parser = Canql::Parser.new('all cases with mother born between 10/01/2000 and 10/10/2010')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
+    assert_equal({ Canql::LIMITS => %w[2000-01-10 2010-10-10] },
                  parser.meta_data['mother.birthdate'])
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -31,7 +31,7 @@ class CasaAgeTest < Minitest::Test
   def test_should_filter_by_mothers_exect_birth_date
     parser = Canql::Parser.new('all cases with mother born on 10/01/2000')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
+    assert_equal({ Canql::LIMITS => %w[2000-01-10 2000-01-10] },
                  parser.meta_data['mother.birthdate'])
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -39,7 +39,7 @@ class CasaAgeTest < Minitest::Test
   def test_should_filter_by_case_death_date_range
     parser = Canql::Parser.new('all cases who died between 10/01/2000 and 10/10/2010')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
+    assert_equal({ Canql::LIMITS => %w[2000-01-10 2010-10-10] },
                  parser.meta_data['patient.deathdate'])
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -47,7 +47,7 @@ class CasaAgeTest < Minitest::Test
   def test_should_filter_by_case_exect_death_date
     parser = Canql::Parser.new('all cases that died on 10/01/2000')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
+    assert_equal({ Canql::LIMITS => %w[2000-01-10 2000-01-10] },
                  parser.meta_data['patient.deathdate'])
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -55,7 +55,7 @@ class CasaAgeTest < Minitest::Test
   def test_should_filter_by_mothers_death_date_range
     parser = Canql::Parser.new('all cases with mother that died between 10/01/2000 and 10/10/2010')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
+    assert_equal({ Canql::LIMITS => %w[2000-01-10 2010-10-10] },
                  parser.meta_data['mother.deathdate'])
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -63,7 +63,7 @@ class CasaAgeTest < Minitest::Test
   def test_should_filter_by_mothers_exect_death_date
     parser = Canql::Parser.new('all cases with mother who died on 10/01/2000')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
+    assert_equal({ Canql::LIMITS => %w[2000-01-10 2000-01-10] },
                  parser.meta_data['mother.deathdate'])
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -73,9 +73,9 @@ class CasaAgeTest < Minitest::Test
       'all cases born between 10/01/2000 and 10/10/2010 and that died on 01/01/2015'
     )
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
+    assert_equal({ Canql::LIMITS => %w[2000-01-10 2010-10-10] },
                  parser.meta_data['patient.birthdate'])
-    assert_equal({ Canql::LIMITS => ['2015-01-01', '2015-01-01'] },
+    assert_equal({ Canql::LIMITS => %w[2015-01-01 2015-01-01] },
                  parser.meta_data['patient.deathdate'])
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -85,9 +85,9 @@ class CasaAgeTest < Minitest::Test
       'all cases with mother born between 10/01/2000 and 10/10/2010 and that died on 01/01/2015'
     )
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
+    assert_equal({ Canql::LIMITS => %w[2000-01-10 2010-10-10] },
                  parser.meta_data['mother.birthdate'])
-    assert_equal({ Canql::LIMITS => ['2015-01-01', '2015-01-01'] },
+    assert_equal({ Canql::LIMITS => %w[2015-01-01 2015-01-01] },
                  parser.meta_data['mother.deathdate'])
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -96,7 +96,7 @@ class CasaAgeTest < Minitest::Test
     parser = Canql::Parser.new('all cases born in Q1 2015')
     assert parser.valid?, parser.failure_reason
     assert_nil parser.failure_reason
-    assert_equal({ Canql::LIMITS => ['2015-04-01', '2015-06-30'] },
+    assert_equal({ Canql::LIMITS => %w[2015-04-01 2015-06-30] },
                  parser.meta_data['patient.birthdate'])
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end

--- a/test/nodes/case_test.rb
+++ b/test/nodes/case_test.rb
@@ -354,7 +354,7 @@ class CaseTest < Minitest::Test
     assert_equal(parser1.meta_data, parser2.meta_data, message3)
   end
 
-  def test_should_not_filter_for_field_existance_on_nonmother_field
+  def test_should_not_filter_for_field_existence_on_nonmother_field
     parser = Canql::Parser.new('all cases with mother with populated outcome')
     refute parser.valid?
   end

--- a/test/nodes/case_test.rb
+++ b/test/nodes/case_test.rb
@@ -121,7 +121,7 @@ class CaseTest < Minitest::Test
   def test_should_filter_on_edd_word_range
     parser = Canql::Parser.new('all cases expected between today and tomorrow')
     assert parser.valid?
-    today = Date.today
+    today = Date.current
     tomorrow = today + 1
     assert_equal(
       { Canql::LIMITS => [today.strftime('%Y-%m-%d'), tomorrow.strftime('%Y-%m-%d')] },

--- a/test/nodes/code_test.rb
+++ b/test/nodes/code_test.rb
@@ -674,7 +674,7 @@ class CodeTest < Minitest::Test
   end
 
   def test_should_filter_with_multiple_anomaly_types
-    parser = Canql::Parser.new('all cases with suspected prenatal q2 anomalies and '\
+    parser = Canql::Parser.new('all cases with suspected prenatal q2 anomalies and ' \
                                'no confirmed postnatal q3 or q4 anomalies')
     assert parser.valid?
 

--- a/test/nodes/events_test.rb
+++ b/test/nodes/events_test.rb
@@ -13,8 +13,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'hes', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'hes', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -25,8 +25,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'hes', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'hes', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -37,8 +37,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'hes', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'hes', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -49,8 +49,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'hes', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'hes', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -61,8 +61,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>false, 'type'=>'hes', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => false, 'type' => 'hes', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -73,8 +73,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>false, 'type'=>'hes', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => false, 'type' => 'hes', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -85,8 +85,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>false, 'type'=>'hes', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => false, 'type' => 'hes', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -97,8 +97,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>false, 'type'=>'hes', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => false, 'type' => 'hes', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -109,8 +109,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'birth', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'birth', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -121,8 +121,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'birth', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'birth', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -133,8 +133,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>false, 'type'=>'birth', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => false, 'type' => 'birth', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -145,8 +145,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>false, 'type'=>'birth', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => false, 'type' => 'birth', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -157,8 +157,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'death', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'death', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -169,8 +169,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'death', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'death', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -181,8 +181,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>false, 'type'=>'death', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => false, 'type' => 'death', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -193,8 +193,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>false, 'type'=>'death', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => false, 'type' => 'death', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -205,8 +205,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'pregnancy_loss_hes', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'pregnancy_loss_hes', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -217,8 +217,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'pregnancy_loss_hes', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'pregnancy_loss_hes', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -229,8 +229,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>false, 'type'=>'pregnancy_loss_hes', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => false, 'type' => 'pregnancy_loss_hes', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -241,8 +241,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>false, 'type'=>'pregnancy_loss_hes', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => false, 'type' => 'pregnancy_loss_hes', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -253,8 +253,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'pregnancy_loss_bpas', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'pregnancy_loss_bpas', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -265,8 +265,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'pregnancy_loss_bpas', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'pregnancy_loss_bpas', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -277,8 +277,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>false, 'type'=>'pregnancy_loss_bpas', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => false, 'type' => 'pregnancy_loss_bpas', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -289,8 +289,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>false, 'type'=>'pregnancy_loss_bpas', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => false, 'type' => 'pregnancy_loss_bpas', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -301,8 +301,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'msds', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'msds', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -313,8 +313,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'msds', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'msds', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -325,8 +325,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>false, 'type'=>'msds', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => false, 'type' => 'msds', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -337,8 +337,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>false, 'type'=>'msds', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => false, 'type' => 'msds', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -439,8 +439,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'pregnancy_loss_hes', 'relevant'=>true}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'pregnancy_loss_hes', 'relevant' => true }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -451,8 +451,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'pregnancy_loss_bpas', 'relevant'=>true}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'pregnancy_loss_bpas', 'relevant' => true }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -463,14 +463,11 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'msds', 'relevant'=>true}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'msds', 'relevant' => true }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
-
-
-
 
   def test_should_filter_cases_by_some_ublinked_preg_loss_hes_events
     parser = Canql::Parser.new('all cases with some unlinked pregnancy loss hes events')
@@ -478,8 +475,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'pregnancy_loss_hes', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'pregnancy_loss_hes', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -490,8 +487,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'pregnancy_loss_bpas', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'pregnancy_loss_bpas', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
@@ -502,8 +499,8 @@ class EventsTest < Minitest::Test
     assert_dir_block_count parser, 'events', 1
     assert_dir_block_values(
       parser, 'events',
-      ['equals', 'type', 'relevant']  , 0,
-      {'equals'=>true, 'type'=>'msds', 'relevant'=>false}
+      %w[equals type relevant], 0,
+      { 'equals' => true, 'type' => 'msds', 'relevant' => false }
     )
     assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end

--- a/test/nodes/genetic_tests_test.rb
+++ b/test/nodes/genetic_tests_test.rb
@@ -44,7 +44,7 @@ class GeneticTest < Minitest::Test
     assert_dir_block_values(parser, 'genetic_tests', %w[exists], index, expected)
   end
 
-  def assert_genetic_test_count(parser, numder_of_blocks)
-    assert_dir_block_count(parser, 'genetic_tests', numder_of_blocks)
+  def assert_genetic_test_count(parser, number_of_blocks)
+    assert_dir_block_count(parser, 'genetic_tests', number_of_blocks)
   end
 end

--- a/test/nodes/mother_e_base_records_test.rb
+++ b/test/nodes/mother_e_base_records_test.rb
@@ -145,31 +145,31 @@ class MotherEBaseRecordsTest < Minitest::Test
   def test_should_filter_mother_on_ebr_specific_processing_date
     parser = Canql::Parser.new('all cases with mother with unprocessed records dated on 20/06/2015')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2015-06-20', '2015-06-20'] },
+    assert_equal({ Canql::LIMITS => %w[2015-06-20 2015-06-20] },
                  parser.meta_data['unprocessed_records.mother.processing_date'])
 
     parser = Canql::Parser.new('all cases with mother with unprocessed records dated for processing on 20/06/2015')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2015-06-20', '2015-06-20'] },
+    assert_equal({ Canql::LIMITS => %w[2015-06-20 2015-06-20] },
                  parser.meta_data['unprocessed_records.mother.processing_date'])
   end
 
   def test_should_filter_mother_on_ebr_processing_date_range
     parser = Canql::Parser.new('all cases with mother with unprocessed records dated between 20/06/2015 and 25/06/2015')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2015-06-20', '2015-06-25'] },
+    assert_equal({ Canql::LIMITS => %w[2015-06-20 2015-06-25] },
                  parser.meta_data['unprocessed_records.mother.processing_date'])
 
     parser = Canql::Parser.new('all cases with mother with unprocessed records dated for processing between 20/06/2015 and 25/06/2015')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2015-06-20', '2015-06-25'] },
+    assert_equal({ Canql::LIMITS => %w[2015-06-20 2015-06-25] },
                  parser.meta_data['unprocessed_records.mother.processing_date'])
   end
 
   def test_should_filter_mother_on_ebr_processing_date_word_range
     parser = Canql::Parser.new('all cases with mother with unprocessed records dated between today and tomorrow')
     assert parser.valid?
-    today = Date.today
+    today = Date.current
     tomorrow = today + 1
     assert_equal(
       { Canql::LIMITS => [today.strftime('%Y-%m-%d'), tomorrow.strftime('%Y-%m-%d')] },
@@ -178,7 +178,7 @@ class MotherEBaseRecordsTest < Minitest::Test
 
     parser = Canql::Parser.new('all cases with mother with unprocessed records dated for processing between today and tomorrow')
     assert parser.valid?
-    today = Date.today
+    today = Date.current
     tomorrow = today + 1
     assert_equal(
       { Canql::LIMITS => [today.strftime('%Y-%m-%d'), tomorrow.strftime('%Y-%m-%d')] },

--- a/test/nodes/patient_age_test.rb
+++ b/test/nodes/patient_age_test.rb
@@ -7,7 +7,7 @@ class PatientAgeTest < Minitest::Test
   def test_should_filter_by_case_birth_date_range
     parser = Canql::Parser.new('all patients born between 10/01/2000 and 10/10/2010')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
+    assert_equal({ Canql::LIMITS => %w[2000-01-10 2010-10-10] },
                  parser.meta_data['patient.birthdate'])
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -15,7 +15,7 @@ class PatientAgeTest < Minitest::Test
   def test_should_filter_by_case_exect_birth_date
     parser = Canql::Parser.new('all patients born on 10/01/2000')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
+    assert_equal({ Canql::LIMITS => %w[2000-01-10 2000-01-10] },
                  parser.meta_data['patient.birthdate'])
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -23,7 +23,7 @@ class PatientAgeTest < Minitest::Test
   def test_should_filter_by_case_death_date_range
     parser = Canql::Parser.new('all patients who died between 10/01/2000 and 10/10/2010')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
+    assert_equal({ Canql::LIMITS => %w[2000-01-10 2010-10-10] },
                  parser.meta_data['patient.deathdate'])
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -31,7 +31,7 @@ class PatientAgeTest < Minitest::Test
   def test_should_filter_by_case_exect_death_date
     parser = Canql::Parser.new('all patients that died on 10/01/2000')
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
+    assert_equal({ Canql::LIMITS => %w[2000-01-10 2000-01-10] },
                  parser.meta_data['patient.deathdate'])
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -41,9 +41,9 @@ class PatientAgeTest < Minitest::Test
       'all patients born between 10/01/2000 and 10/10/2010 and that died on 01/01/2015'
     )
     assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
+    assert_equal({ Canql::LIMITS => %w[2000-01-10 2010-10-10] },
                  parser.meta_data['patient.birthdate'])
-    assert_equal({ Canql::LIMITS => ['2015-01-01', '2015-01-01'] },
+    assert_equal({ Canql::LIMITS => %w[2015-01-01 2015-01-01] },
                  parser.meta_data['patient.deathdate'])
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
@@ -52,7 +52,7 @@ class PatientAgeTest < Minitest::Test
     parser = Canql::Parser.new('all patients born in Q1 2015')
     assert parser.valid?, parser.failure_reason
     assert_nil parser.failure_reason
-    assert_equal({ Canql::LIMITS => ['2015-04-01', '2015-06-30'] },
+    assert_equal({ Canql::LIMITS => %w[2015-04-01 2015-06-30] },
                  parser.meta_data['patient.birthdate'])
     assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end

--- a/test/nodes/test_result_groups_test.rb
+++ b/test/nodes/test_result_groups_test.rb
@@ -185,7 +185,7 @@ class TestResultGroupsTest < Minitest::Test
 
     assert parser.valid?
 
-    assert_test_accesptance_count parser, 1
+    assert_test_acceptance_count parser, 1
     assert_test_acceptance_values(
       parser, 0,
       'exists' => { Canql::EQUALS => false },
@@ -200,7 +200,7 @@ class TestResultGroupsTest < Minitest::Test
 
     assert parser.valid?
 
-    assert_test_accesptance_count parser, 1
+    assert_test_acceptance_count parser, 1
     assert_test_acceptance_values(
       parser, 0,
       'exists' => { Canql::EQUALS => false },
@@ -215,7 +215,7 @@ class TestResultGroupsTest < Minitest::Test
 
     assert parser.valid?
 
-    assert_test_accesptance_count parser, 1
+    assert_test_acceptance_count parser, 1
     assert_test_acceptance_values(
       parser, 0,
       'exists' => { Canql::EQUALS => false },
@@ -230,7 +230,7 @@ class TestResultGroupsTest < Minitest::Test
 
     assert parser.valid?
 
-    assert_test_accesptance_count parser, 1
+    assert_test_acceptance_count parser, 1
     assert_test_acceptance_values(
       parser, 0,
       'exists' => { Canql::EQUALS => false },
@@ -260,15 +260,15 @@ class TestResultGroupsTest < Minitest::Test
     assert_dir_block_values(parser, 'test_acceptances', %w[exists acceptance required], index, expected)
   end
 
-  def assert_test_accesptance_count(parser, numder_of_blocks)
-    assert_dir_block_count(parser, 'test_acceptances', numder_of_blocks)
+  def assert_test_acceptance_count(parser, number_of_blocks)
+    assert_dir_block_count(parser, 'test_acceptances', number_of_blocks)
   end
 
   def assert_test_result_group_values(parser, index = 0, expected = {})
     assert_dir_block_values(parser, 'test_result_groups', %w[exists group required], index, expected)
   end
 
-  def assert_test_result_group_count(parser, numder_of_blocks)
-    assert_dir_block_count(parser, 'test_result_groups', numder_of_blocks)
+  def assert_test_result_group_count(parser, number_of_blocks)
+    assert_dir_block_count(parser, 'test_result_groups', number_of_blocks)
   end
 end

--- a/test/nodes/test_results_test.rb
+++ b/test/nodes/test_results_test.rb
@@ -98,7 +98,7 @@ class TestResultsTest < Minitest::Test
     assert_dir_block_values(parser, 'test_results', %w[exists type status icd_codes], index, expected)
   end
 
-  def assert_test_result_count(parser, numder_of_blocks)
-    assert_dir_block_count(parser, 'test_results', numder_of_blocks)
+  def assert_test_result_count(parser, number_of_blocks)
+    assert_dir_block_count(parser, 'test_results', number_of_blocks)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,11 +35,11 @@ def assert_array_includes(array, subset)
   assert((subset - array).empty?)
 end
 
-def assert_dir_block_count(parser, block_type, numder_of_blocks)
-  return true if parser.meta_data[block_type].blank? && numder_of_blocks.zero?
+def assert_dir_block_count(parser, block_type, number_of_blocks)
+  return true if parser.meta_data[block_type].blank? && number_of_blocks.zero?
 
   assert parser.meta_data[block_type].present?, 'No DIR blocks to count'
-  assert_equal numder_of_blocks, parser.meta_data.dig(block_type, Canql::ALL).count
+  assert_equal number_of_blocks, parser.meta_data.dig(block_type, Canql::ALL).count
 end
 
 def assert_dir_block_values(parser, block_type, all_keys = nil, index = 0, expected = {})


### PR DESCRIPTION
- Code only misspelling of existence
- Code only misspelling of modifier
- Code only misspelling of number
- Code only misspelling of acceptance
- Mass Rubocop

NOTE: Gemspec MFA requirement Rubocop warning ignored for now, as it the finak 'return' warning, as I'm undecided whether to implant the code change in the comment.