### PR TITLE
Restrict treetop gem dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-* no unreleased changes *
+### Fixed
+* Restrict treetop gem dependency
 
 ## 6.0.2 / 2024-11-18
 ### Fixed

--- a/canql.gemspec
+++ b/canql.gemspec
@@ -28,7 +28,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'chronic', '~> 0.3'
   spec.add_dependency 'ndr_support', '>= 3.0', '< 6'
   spec.add_dependency 'rails', '>= 7.0', '< 8.1'
-  spec.add_dependency 'treetop', '>= 1.4.10'
+  # treetop 1.6.14 causes errors. I think this may be a buggy release and fixed soon,
+  # but I'll restrict the version we use for now.
+  spec.add_dependency 'treetop', '~> 1.6.12', '< 1.6.14'
 
   # spec.add_development_dependency 'bundler'
   # spec.add_development_dependency 'guard'

--- a/gemfiles/Gemfile.rails70
+++ b/gemfiles/Gemfile.rails70
@@ -14,3 +14,6 @@ gem 'github-linguist'
 gem 'pry'
 gem 'rake'
 gem 'terminal-notifier-guard' if RUBY_PLATFORM =~ /darwin/
+
+# Latest concurrent-ruby breaks Rails < 7.1. See https://github.com/rails/rails/issues/54260
+gem 'concurrent-ruby', '1.3.4'


### PR DESCRIPTION
Restrict `treetop` gem dependency. `treetop` 1.6.14 causes errors. I think this may be a buggy release and fixed soon, but I'll restrict the version we use for now so that everything continues to work.

Fix `concurrent-ruby` version to 1.3.4 for older Rails versions.