### PR TITLE
Bump to version 6.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [Unreleased]
+* no unreleased changes *
+
+## 6.0.3 / 2025-06-11
 ### Fixed
 * Restrict treetop gem dependency
 

--- a/lib/canql/version.rb
+++ b/lib/canql/version.rb
@@ -2,5 +2,5 @@
 
 # This stores the current version of the Canql gem
 module Canql
-  VERSION = '6.0.2'
+  VERSION = '6.0.3'
 end


### PR DESCRIPTION
This is a minor release: it rolls up a minor gem dependency change.